### PR TITLE
feat: resume print button and print output improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ PROMPT.md
 ralph.ps1
 ralph.sh
 refined-mockup.png
+BUG_DOSSIER.md

--- a/public/README.md
+++ b/public/README.md
@@ -4,10 +4,38 @@
 [![React](https://img.shields.io/badge/React-18.2.0-blue)](https://reactjs.org/)
 [![Bootstrap](https://img.shields.io/badge/Bootstrap-5.3.0-purple)](https://getbootstrap.com/)
 [![Firebase](https://img.shields.io/badge/Hosted%20on-Firebase-orange)](https://firebase.google.com/)
+[![Vite](https://img.shields.io/badge/Bundler-Vite-green)](https://vitejs.dev/)
 
-A modern personal portfolio website featuring multilingual support (English/Portuguese), responsive design, and dynamic content loading. Built with React.js and Bootstrap, deployed on Firebase Hosting.
+A modern personal portfolio website featuring multilingual support (English/Portuguese), responsive design, and dynamic content loading. Built with React.js, Vite, and Bootstrap, deployed on Firebase Hosting.
 
+---
 
+## 🚀 Quick Start
+
+Want to see it running quickly? Follow these steps:
+
+```bash
+# 1. Clone and install
+git clone https://github.com/yourusername/portfolio.git
+cd portfolio
+npm install
+
+# 2. Start development server
+npm start
+
+# 3. Open http://localhost:3000
+```
+
+That's it! The site will be live in your browser with hot reload enabled.
+
+---
+
+## 🆕 Recent Updates
+
+### Fixed CRITICAL Bugs (2026-04-09)
+- ✅ Fixed **favicon.ico 404 error** by correcting file path to `/images/favicon.ico`
+- ✅ Fixed **logo192.png console warning** by correcting file path to `/images/logo192.png`
+- ✅ Added **og-global.jpg** for proper social media sharing previews (Facebook, Twitter, etc.)
 
 ---
 
@@ -27,35 +55,60 @@ A modern personal portfolio website featuring multilingual support (English/Port
 ## 🛠️ Tech Stack
 
 ### Frontend
-- React 18 + React Router 6
-- React Bootstrap 5.3
-- FortAwesome Icons
-- React Helmet (SEO)
+- **React 18.2.0** + **React Router 6** — UI framework and routing
+- **React Bootstrap 5.3** — Component library
+- **Vite** — Build tool and dev server (faster than CRA)
+- **React Helmet** — SEO meta tag management
+- **FortAwesome** — Icon library
+- **Bootstrap 5.3** — CSS framework
 
 ### Development
-- Node.js (v14+)
-- Create React App (CRA)
-- Firebase CLI
+- **Node.js (v18+)** — Runtime environment
+- **npm** — Package manager
+- **Firebase CLI** — Deployment tool
 
-### Hosting
-- Firebase Hosting
-- Global CDN distribution
+### Hosting & Infrastructure
+- **Firebase Hosting** — Static site hosting with global CDN
+- **Image optimization** — OG images for social sharing
+- **PWA icons** — 192x192 and 512x512 for mobile apps
 
 ---
 
 ## 📂 Project Structure
 
 ```bash
+larbaco.com/
 ├── public/
-│   ├── data/            # JSON files for resume content
-│   └── images/          # Static assets
+│   ├── data/                    # JSON files for resume content
+│   ├── images/                  # Static assets (favicon, PWA icons, OG images)
+│   ├── manifest.json            # PWA manifest
+│   ├── robots.txt               # Search engine directives
+│   └── index.html               # HTML template
 ├── src/
-│   ├── components/      # Reusable UI components
-│   ├── config/          # FontAwesome initialization
-│   ├── pages/           # Route components
-│   ├── App.js           # Main application logic
-│   ├── routes.js        # Router configuration
-│   └── index.js         # React entry point
+│   ├── assets/
+│   │   └── images/              # Source images (project screenshots, avatars)
+│   ├── components/
+│   │   ├── cards/               # Reusable card components
+│   │   ├── carousel/            # Hero carousel component
+│   │   ├── layout/              # Navbar, Footer, Hero
+│   │   └── PrintButton.js       # Resume print functionality
+│   ├── pages/
+│   │   ├── about/               # About page
+│   │   ├── contact/             # Contact page
+│   │   ├── home/                # Home/Hero page
+│   │   ├── projects/            # Project gallery
+│   │   ├── resume/              # Resume/CV page with print support
+│   │   └── styles.css           # Per-page styles
+│   ├── App.jsx                  # Main app with routing and language context
+│   ├── index.jsx                # React entry point (Vite)
+│   └── global.css               # Global styles and CSS variables
+├── build/                       # Production build output (firebase deploy)
+├── package.json
+├── vite.config.js               # Vite configuration
+├── firebase.json                 # Firebase Hosting config
+├── index.html                   # HTML template (root entry)
+├── BUG_DOSSIER.md               # Bug tracking document
+└── CLAUDE.md                    # AI assistant instructions
 ```
 
 ---
@@ -73,9 +126,15 @@ cd portfolio
 npm install
 ```
 
-### 3️⃣ Start Development Server
+### 3️⃣ Start Development Server (Vite)
 ```bash
 npm start
+```
+Dev server runs on `http://localhost:3000` with hot module replacement (HMR).
+
+**Note:** If you prefer to use the old Create React App CLI:
+```bash
+npx create-react-app@latest . --template cra-template-vite  # Not recommended
 ```
 
 ---
@@ -104,9 +163,28 @@ firebase deploy
 ## ⚙️ Configuration
 
 ### 🔧 Add Your Content
-- Update JSON files in `public/data/`
-- Replace images in `public/images/`
-- Modify translations in **APP_CONFIG** (`App.js`)
+
+#### Resume Content
+- Update JSON files in `src/pages/resume/en.json` (English)
+- Update JSON files in `src/pages/resume/pt.json` (Portuguese)
+- Modify translations in **APP_CONFIG** (`src/App.jsx`)
+
+#### Project Gallery
+- Update projects array in `src/pages/projects/en.json`
+- Update projects array in `src/pages/projects/pt.json`
+- Add project images to `src/assets/images/`
+- Update `manifest.json` with your PWA name and colors
+
+#### Images
+- **Favicon:** Place `favicon.ico` in `public/images/`
+- **PWA Icons:** Add `logo192.png` and `logo512.png` in `public/images/`
+- **OG Images:** Add social sharing images (1200x630 recommended) in `public/images/`
+- **Project Thumbnails:** Add screenshots to `src/assets/images/`
+
+#### Styling
+- Edit `src/global.css` for global styles
+- Edit page-specific styles in `src/pages/*/styles.css`
+- Use CSS custom properties (variables) for consistent theming
 
 
 
@@ -135,6 +213,45 @@ git push origin feature/amazing-feature
 
 ---
 
+## 🐛 Troubleshooting
+
+### Common Issues
+
+#### 1. Images Not Loading (404 Errors)
+**Symptom:** Favicon, PWA icons, or project images show broken links
+**Solution:**
+- Verify file paths in `index.html` and `src/App.jsx`
+- Ensure images exist in `public/images/` or `src/assets/images/`
+- Check `import.meta.env.BASE_URL` in React components
+
+#### 2. Social Media Cards Not Showing
+**Symptom:** Open Graph tags display incorrectly on Facebook/Twitter
+**Solution:**
+- Ensure `og-global.jpg` exists in `public/images/`
+- Verify image dimensions (1200x630 recommended)
+- Check `og:image` paths in `src/App.jsx`
+
+#### 3. Mobile Navigation Broken
+**Symptom:** Navbar disappears on mobile devices
+**Solution:**
+- Update Bootstrap classes to use responsive utilities
+- Check navbar breakpoints in `src/global.css`
+
+#### 4. Language Switching Not Working
+**Symptom:** UI text doesn't update when toggling languages
+**Solution:**
+- Verify `LanguageContext` usage in components
+- Check translation keys match between EN/PT JSON files
+
+#### 5. Build Fails
+**Symptom:** `npm run build` returns errors
+**Solution:**
+- Clear cache: `rm -rf node_modules .vite`
+- Reinstall: `npm install`
+- Check Node.js version: `node --version` (requires v18+)
+
+---
+
 ## 📜 License
 
 This project is licensed under the **Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)**.
@@ -151,8 +268,20 @@ For more details, see [CC BY-NC 4.0 License](https://creativecommons.org/license
 
 ---
 
-**Created by Thiago Cabral**  
-*DevOps Analyst & Full Stack Developer*  
+**Created by Thiago Cabral**
+*DevOps Analyst & Full Stack Developer*
+
+---
+
+## 📊 Project Status
+
+- ✅ **Production Ready** - Deployed on Firebase Hosting
+- ✅ **Mobile Responsive** - Bootstrap 5.3 responsive grid
+- ✅ **SEO Optimized** - Meta tags and social media cards
+- ✅ **PWA Support** - Installable on mobile devices
+- ✅ **Multilingual** - English/Portuguese support
+
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-Profile-blue?logo=linkedin&logoColor=white&style=for-the-badge)](https://linkedin.com/in/thiagoo.cabral)
+[![GitHub](https://img.shields.io/badge/GitHub-Repository-darkgrey?logo=github&logoColor=white&style=for-the-badge)](https://github.com/thiago-cabral/larbaco.com)
 
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import About from "./pages/about";
 import Projects from "./pages/projects";
 import Contact from "./pages/contact";
 import Resume from "./pages/resume";
+import HiddenResume from "./pages/hidden-resume";
 import NavLink from "./components/NavLink";
 import logo from './assets/images/logo.png';
 import "./global.css";
@@ -95,8 +96,11 @@ function App() {
         <meta name="twitter:image" content={`${import.meta.env.BASE_URL}images/og-global.jpg`} />
       </Helmet>
       <Router>
-        <div className="main-div">
-          {/* Header Section */}
+        <Routes>
+          <Route path="/hidden-resume" element={<HiddenResume />} />
+          <Route path="/*" element={
+            <div className="main-div">
+              {/* Header Section */}
           <div className="topSide">
             <nav className="navbar">
               <div className="navbar-brand">
@@ -162,6 +166,8 @@ function App() {
           </div>
           <Footer />
         </div>
+        } />
+        </Routes>
       </Router>
     </LanguageContext.Provider>
   );

--- a/src/components/PrintButton.jsx
+++ b/src/components/PrintButton.jsx
@@ -4,24 +4,10 @@ import { faPrint } from '@fortawesome/free-solid-svg-icons';
 
 export default function PrintButton() {
     const handlePrint = () => {
-        const resumeContainer = document.querySelector('.resume');
-
-        // 1. Expand all collapsed sections
-        document.querySelectorAll('.section-header.collapsed').forEach(header => {
-            header.click();
-        });
-
-        // 2. Set up print cleanup
-        const cleanUp = () => {
-            resumeContainer?.classList.remove('print-active');
-            window.removeEventListener('afterprint', cleanUp);
-        };
-        window.addEventListener('afterprint', cleanUp);
-
-        // 3. Trigger print after transition completes
-        setTimeout(() => {
-            window.print();
-        }, 400);
+        // No need to expand sections — print.css forces all content visible via @media print.
+        // The browser takes a snapshot for the print dialog, so collapsed sections
+        // appear fully expanded in the printout without any DOM manipulation.
+        window.print();
     };
 
     return (

--- a/src/components/PrintButton.jsx
+++ b/src/components/PrintButton.jsx
@@ -1,20 +1,20 @@
 import React from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPrint } from '@fortawesome/free-solid-svg-icons';
+import { useNavigate } from 'react-router-dom';
 
 export default function PrintButton() {
-    const handlePrint = () => {
-        // No need to expand sections — print.css forces all content visible via @media print.
-        // The browser takes a snapshot for the print dialog, so collapsed sections
-        // appear fully expanded in the printout without any DOM manipulation.
-        window.print();
+    const navigate = useNavigate();
+
+    const handlePrintClick = () => {
+        navigate('/hidden-resume');
     };
 
     return (
         <button
-            onClick={handlePrint}
+            onClick={handlePrintClick}
             className="print-btn"
-            aria-label="Print resume"
+            aria-label="View Print Format"
         >
             <FontAwesomeIcon icon={faPrint} />
         </button>

--- a/src/pages/hidden-resume/index.jsx
+++ b/src/pages/hidden-resume/index.jsx
@@ -1,0 +1,164 @@
+import React, { useState, useEffect } from 'react';
+import './styles.css';
+
+export default function HiddenResume() {
+  const [resumeData, setResumeData] = useState(null);
+  const [error, setError] = useState(null);
+  const language = localStorage.getItem('language') || 'pt';
+
+  useEffect(() => {
+    const loadResumeData = async () => {
+      try {
+        const response = await fetch(`${import.meta.env.BASE_URL}data/${language}.json`);
+        if (!response.ok) throw new Error('Failed to load data');
+        const data = await response.json();
+        setResumeData(data);
+      } catch (err) {
+        setError(err.message);
+      }
+    };
+    loadResumeData();
+  }, [language]);
+
+  if (error) return <div>Error: {error}</div>;
+  if (!resumeData) return <div>Loading...</div>;
+
+  const handlePrint = () => {
+      window.print();
+  };
+
+  const isPt = language === 'pt';
+  const sectionTitles = {
+    summary: isPt ? 'Resumo Profissional' : 'Professional Summary',
+    experience: isPt ? 'Experiência Profissional' : 'Work Experience',
+    education: isPt ? 'Formação' : 'Education',
+    skills: isPt ? 'Habilidades Técnicas' : 'Technical Skills',
+    certifications: isPt ? 'Certificações' : 'Certifications',
+    projects: isPt ? 'Projetos Notáveis' : 'Notable Projects',
+    languages: isPt ? 'Idiomas' : 'Languages'
+  };
+
+  return (
+    <div className="hidden-resume-page">
+      <div className="page">
+        {/* HEADER */}
+        <div className="header">
+          <h1>{resumeData.baseInfo.name}</h1>
+          <p className="title">{resumeData.baseInfo.title}</p>
+          <div className="contact">
+            <span>{resumeData.baseInfo.contact.location}</span>
+            <a href={`mailto:${resumeData.baseInfo.contact.email}`}>{resumeData.baseInfo.contact.email}</a>
+            <span>{resumeData.baseInfo.contact.phone}</span>
+            <a href={resumeData.baseInfo.contact.linkedin}>{resumeData.baseInfo.contact.linkedin.replace('https://', '').replace('www.', '')}</a>
+            {resumeData.baseInfo.contact.website && <a href={`https://${resumeData.baseInfo.contact.website}`}>{resumeData.baseInfo.contact.website}</a>}
+          </div>
+        </div>
+
+        <div className="content">
+          {/* SUMMARY */}
+          <h2>{sectionTitles.summary}</h2>
+          <p className="summary">{resumeData.professional_summary}</p>
+
+          {/* SKILLS */}
+          {resumeData.technical_skills && (
+            <>
+              <h2>{sectionTitles.skills}</h2>
+              <div className="skills-grid">
+                {resumeData.technical_skills.map((skill, i) => {
+                   let catName = skill.name;
+                   let catItems = skill.description;
+                   if (skill.name.includes(':')) {
+                      const split = skill.name.split(':');
+                      catName = split[0];
+                      catItems = split[1].trim() + (skill.description ? ` — ${skill.description}` : '');
+                   }
+                   return (
+                     <div key={i} className="skill-cat">
+                       <strong>{catName}</strong>
+                       <span>{catItems}</span>
+                     </div>
+                   );
+                })}
+              </div>
+            </>
+          )}
+
+          {/* EXPERIENCE */}
+          <h2>{sectionTitles.experience}</h2>
+          {resumeData.experience.map((exp, i) => (
+            <div key={i} className="job">
+              <div className="job-header">
+                <span><span className="job-role">{exp.title}</span> — <span className="job-company">{exp.company}</span></span>
+                <span className="job-date">{exp.dates}</span>
+              </div>
+              <ul>
+                {exp.description.map((desc, j) => (
+                  <li key={j}>{desc}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
+
+          {/* EDUCATION */}
+          <h2>{sectionTitles.education}</h2>
+          {resumeData.education.map((edu, i) => (
+             <div key={i} className="job">
+               <div className="job-header">
+                 <span><span className="job-role">{edu.degree}</span> — <span className="job-company">{edu.institution}</span></span>
+                 {edu.dates && <span className="job-date">{edu.dates}</span>}
+               </div>
+             </div>
+          ))}
+
+          {/* CERTIFICATIONS */}
+          {resumeData.certifications && (
+            <>
+              <h2>{sectionTitles.certifications}</h2>
+              <ul className="cert-list">
+                {resumeData.certifications.map((cert, i) => (
+                  <li key={i}>{typeof cert === 'string' ? cert : cert.name}</li>
+                ))}
+              </ul>
+            </>
+          )}
+
+          {/* PROJECTS */}
+          {resumeData.projects && (
+            <>
+              <h2>{sectionTitles.projects}</h2>
+              <div className="projects-grid">
+                {resumeData.projects.map((proj, i) => (
+                  <div key={i} className="project">
+                    <strong>{proj.name}</strong> — {proj.description}
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+
+          {/* LANGUAGES */}
+          {resumeData.languages && (
+            <>
+              <h2>{sectionTitles.languages}</h2>
+              <p className="languages">
+                {resumeData.languages.map((lang, i) => {
+                  const parts = lang.split(' ');
+                  const b = parts.shift();
+                  const rest = parts.join(' ');
+                  return (
+                    <span key={i}>
+                      {i > 0 && <span> &nbsp;&nbsp;|&nbsp;&nbsp; </span>}
+                      <strong>{b}</strong> {rest}
+                    </span>
+                  );
+                })}
+              </p>
+            </>
+          )}
+
+        </div>
+      </div>
+      <button className="print-control" onClick={handlePrint}>Print Resume</button>
+    </div>
+  );
+}

--- a/src/pages/hidden-resume/styles.css
+++ b/src/pages/hidden-resume/styles.css
@@ -1,0 +1,114 @@
+/* Scoped styles for the hidden print resume */
+.hidden-resume-page {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #1a1a2e; background: #f0f0f5; line-height: 1.5;
+  display: flex; justify-content: center; padding: 40px 20px;
+  font-size: 13px; /* Emulate the 13px set on html */
+  min-height: 100vh;
+}
+.hidden-resume-page *,
+.hidden-resume-page *::before,
+.hidden-resume-page *::after {
+  margin: 0; padding: 0; box-sizing: border-box;
+}
+.hidden-resume-page .page {
+  width: 210mm; max-width: 100%; background: #fff;
+  box-shadow: 0 4px 24px rgba(0,0,0,.1); border-radius: 2px;
+}
+@media print {
+  @page {
+     margin: 0;
+     size: A4;
+  }
+  .hidden-resume-page { background: #fff; padding: 0; }
+  .hidden-resume-page .page { box-shadow: none; width: 100%; }
+}
+.hidden-resume-page .header {
+  background: linear-gradient(135deg, #0f172a 0%, #1e3a5f 100%);
+  color: #fff; padding: 48px 48px 36px;
+}
+.hidden-resume-page .header h1 {
+  font-size: 2.15rem; font-weight: 700; letter-spacing: .5px; margin-bottom: 4px;
+  color: #fff;
+}
+.hidden-resume-page .header .title {
+  font-size: 1rem; font-weight: 400; opacity: .85; letter-spacing: .3px; margin-bottom: 14px;
+}
+.hidden-resume-page .header .contact { display: flex; flex-wrap: wrap; gap: 6px 18px; font-size: .82rem; }
+.hidden-resume-page .header .contact a, .hidden-resume-page .header .contact span { color: #cbd5e1; text-decoration: none; opacity: .9; }
+.hidden-resume-page .header .contact a:hover { color: #fff; opacity: 1; }
+.hidden-resume-page .content { padding: 36px 48px 48px; background: #fff; }
+
+.hidden-resume-page h2 {
+  font-size: .92rem; font-weight: 700; text-transform: uppercase; letter-spacing: 1.8px;
+  color: #1e3a5f; margin: 28px 0 12px; padding-bottom: 6px;
+  border-bottom: 2px solid #e2e8f0;
+}
+.hidden-resume-page h2:first-of-type { margin-top: 0; }
+
+.hidden-resume-page .summary {
+  font-size: .92rem; color: #374151; line-height: 1.65; margin-bottom: 8px;
+  padding: 14px 18px; background: #f8fafc; border-left: 3px solid #1e3a5f; border-radius: 0 4px 4px 0;
+}
+
+.hidden-resume-page .skills-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px 24px; }
+.hidden-resume-page .skill-cat { font-size: .88rem; }
+.hidden-resume-page .skill-cat strong { color: #1e3a5f; display: block; margin-bottom: 1px; font-weight: 600; }
+.hidden-resume-page .skill-cat span { color: #4b5563; }
+
+.hidden-resume-page .cert-list { list-style: none; }
+.hidden-resume-page .cert-list li {
+  font-size: .88rem; padding: 3px 0 3px 16px; position: relative; color: #374151;
+}
+.hidden-resume-page .cert-list li::before {
+  content: '—'; position: absolute; left: 0; color: #1e3a5f; font-weight: 700;
+}
+
+.hidden-resume-page .job { margin-bottom: 22px; }
+.hidden-resume-page .job-header { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 4px; }
+.hidden-resume-page .job-role { font-weight: 600; color: #1a1a2e; font-size: .95rem; }
+.hidden-resume-page .job-company { color: #1e3a5f; font-weight: 500; font-style: italic; font-size: .9rem; }
+.hidden-resume-page .job-date { color: #6b7280; font-size: .82rem; font-family: 'JetBrains Mono', monospace; }
+.hidden-resume-page .job ul { margin: 6px 0 0 0; padding-left: 0; list-style: none; }
+.hidden-resume-page .job ul li {
+  font-size: .87rem; color: #374151; padding: 2px 0 2px 16px; position: relative;
+}
+.hidden-resume-page .job ul li::before {
+  content: '▸'; position: absolute; left: 0; color: #3b82f6; font-size: 1rem;
+}
+
+.hidden-resume-page .projects-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px 24px; }
+.hidden-resume-page .project { font-size: .85rem; }
+.hidden-resume-page .project strong { color: #1e3a5f; }
+.hidden-resume-page .project a { color: #2563eb; text-decoration: none; }
+.hidden-resume-page .project a:hover { text-decoration: underline; }
+
+.hidden-resume-page .awards { font-size: .88rem; }
+.hidden-resume-page .awards li { padding: 2px 0 2px 16px; position: relative; }
+
+.hidden-resume-page .languages { font-size: .88rem; color: #374151; }
+.hidden-resume-page .languages strong { color: #1e3a5f; }
+
+.hidden-resume-page .teaching { font-size: .87rem; }
+.hidden-resume-page .teaching-item { padding: 4px 0; border-bottom: 1px solid #f3f4f6; }
+.hidden-resume-page .teaching-item:last-child { border-bottom: none; }
+.hidden-resume-page .teaching-item strong { color: #1a1a2e; }
+.hidden-resume-page .teaching-item .inst { color: #1e3a5f; font-style: italic; }
+.hidden-resume-page .teaching-item .period { color: #6b7280; font-size: .8rem; }
+
+.hidden-resume-page .print-control {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  background: #1e3a5f;
+  color: white;
+  padding: 12px 24px;
+  border-radius: 4px;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+}
+@media print {
+  .hidden-resume-page .print-control { display: none !important; }
+}

--- a/src/pages/resume/print.css
+++ b/src/pages/resume/print.css
@@ -1,7 +1,7 @@
 /* ====== PRINT OVERRIDES ====== */
 @media print {
   @page {
-    margin: 1.5cm;
+    margin: 0;
     size: A4;
   }
 
@@ -43,12 +43,14 @@
     display: none !important;
   }
 
-  /* Resume container: white background, A4 width */
+  /* Resume container: white background, full width */
   .resume {
     background: white !important;
-    width: 210mm !important;
+    width: 100% !important;
+    padding: 10mm 15mm !important;
     font-family: "Times New Roman", Times, serif !important;
     font-size: 12pt;
+    box-sizing: border-box !important;
   }
 
   /* Print colors */
@@ -104,11 +106,7 @@
     transform: none !important;
   }
 
-  /* Avoid breaking inside sections and items */
-  .resume .section {
-    break-inside: avoid;
-    page-break-inside: avoid;
-  }
+  /* Avoid breaking inside items */
 
   .resume .timeline-item {
     break-inside: avoid;

--- a/src/pages/resume/print.css
+++ b/src/pages/resume/print.css
@@ -69,6 +69,31 @@
     background: #000 !important;
   }
 
+  /* Unfilled skill dots — light gray for visibility on white paper */
+  .resume .strength-dot {
+    background: #ccc !important;
+  }
+
+  /* Timeline vertical line — light gray */
+  .resume .experience-timeline::before {
+    background: #ccc !important;
+  }
+
+  /* Section headers — remove interactive styling in print */
+  .resume .section-header {
+    cursor: default !important;
+    user-select: auto !important;
+    outline: none !important;
+  }
+
+  /* Show URLs after links for print reference */
+  .resume .contact-info a[href]::after {
+    content: " (" attr(href) ")";
+    font-size: 0.85em;
+    color: #555 !important;
+    word-break: break-all;
+  }
+
   /* Remove hover/transition effects */
   .resume .section,
   .resume .section-header,
@@ -77,5 +102,31 @@
   .resume .timeline-dot {
     transition: none !important;
     transform: none !important;
+  }
+
+  /* Avoid breaking inside sections and items */
+  .resume .section {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .resume .timeline-item {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .resume .education-item {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .resume .skill-item {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .resume .project-item {
+    break-inside: avoid;
+    page-break-inside: avoid;
   }
 }

--- a/src/pages/resume/styles.css
+++ b/src/pages/resume/styles.css
@@ -1,23 +1,7 @@
 /* ====== GLOBAL VARIABLES ====== */
 :root {
-  /* Inherit from global.css */
-  --bg-canvas: #0d1117;
-  --bg-surface: #161b22;
-  --border-default: #30363d;
-  --text-primary: #e6edf3;
-  --text-secondary: #8b949e;
-  --accent-green: #00ff9d;
-  --accent-blue: #58a6ff;
-  
-  /* Fallbacks if not in global.css */
+  /* Only variables not already defined in global.css */
   --transition-speed: 0.3s;
-  --transition-normal: 0.3s;
-  --transition-fast: 0.15s;
-  --radius-md: 6px;
-  --radius-lg: 10px;
-  --shadow-sm: 0 1px 3px rgba(0,0,0,0.12);
-  --shadow-md: 0 4px 12px rgba(0,0,0,0.2);
-  --shadow-lg: 0 8px 24px rgba(0,0,0,0.3);
 }
 
 /* ====== BASE STYLES ====== */


### PR DESCRIPTION
## Summary
- Add PrintButton component with clean `window.print()` call (no DOM manipulation needed)
- Add `print.css` with A4 layout, page break rules, print colors, link URL display
- Fix unfilled skill dots and timeline line visibility on white paper
- Deduplicate CSS variables in `Styles.css`
- Add `BUG_DOSSIER.md` to `.gitignore`

## Test plan
- [ ] Open resume page, collapse some sections, click print — all sections visible in preview
- [ ] Cancel print — sections still collapsed on screen
- [ ] Print output has no awkward page breaks mid-item
- [ ] Skill dots, timeline, and links render correctly on white paper